### PR TITLE
Make it easier to activate dedicated envs for literate files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,8 @@ URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 FranklinParser = "0.6"
 IOCapture = "0.2"
 LiveServer = "0.7, 0.8, 0.9, 1, 1.1"
+OrderedCollections = "1.6"
+URIs = "1.4"
 julia = "1.6"
 
 [extras]

--- a/src/context/code/modules.jl
+++ b/src/context/code/modules.jl
@@ -123,7 +123,9 @@ const UTILS_UTILS = [
     "getlvar", "getgvar", "getvarfrom",
     "setlvar!", "setgvar!",
     "locvar", "globvar", "pagevar",
-    "get_page_tags", "get_all_tags", "get_rpath"
+    "get_page_tags", "get_all_tags", "get_rpath",
+    # project
+    "setproject!"
 ]
 
 """
@@ -167,6 +169,7 @@ modules_setup(c::Context) = begin
     for m in (c.nb_vars.mdl, c.nb_code.mdl)
         base_code = """
             using $F
+            import Pkg
 
             const __gc = cur_gc()
             const __lc = get(__gc.children_contexts, "$rpath", nothing)
@@ -175,7 +178,6 @@ modules_setup(c::Context) = begin
             path(s::Symbol)  = $F.path(__gc, s)
             folderpath(p...) = joinpath(path(:folder), p...)
             sitepath(p...)   = joinpath(path(:site), p...)
-
 
             getlvar(n::Symbol, d=nothing; default=d) =
                 $F.getvar(__lc, __lc, n, default)
@@ -202,6 +204,8 @@ modules_setup(c::Context) = begin
             get_page_tags(rp) = $F.get_page_tags(rp)
             get_all_tags()    = $F.get_all_tags(__gc)
             get_rpath()       = $F.get_rpath(__lc)
+
+            setproject!(p::AbstractString) = $F.setproject!(__lc, p)
             """
 
         # Utils module

--- a/src/convert/markdown/latex_objects.jl
+++ b/src/convert/markdown/latex_objects.jl
@@ -330,6 +330,7 @@ function try_resolve_lxcom(
     return Block(:RAW_INLINE, subs(r2)), nargs
 end
 
+
 """
     is_in_utils(gc, n; isenv)
 
@@ -345,6 +346,7 @@ function is_in_utils(
         (n in utils_envfun_names(gc)) || (n in INTERNAL_ENVFUNS) :
         (n in utils_lxfun_names(gc))  || (n in INTERNAL_LXFUNS)
 end
+
 
 """
     from_utils(n, i, blocks, lc; isenv, tohtml)
@@ -401,6 +403,7 @@ function from_utils(
     o = outputof(fsymb, args, lc; internal, tohtml)
     return Block(kind, subs(o)), length(args)
 end
+
 
 """
     next_adjacent_brackets(i, blocks, lc)

--- a/src/convert/markdown/lxfuns/utils.jl
+++ b/src/convert/markdown/lxfuns/utils.jl
@@ -50,3 +50,30 @@ function _lx_check_nargs(n::Symbol, p::VS, k::Int)
     end
     return ""
 end
+
+
+"""
+    _lx_split_args_kwargs(s::String)
+
+Attempt at splitting a string of the form "a, b, c; d=..., e=...".
+Return a corresponding (tuple, namedtuple). In the case where the parsing
+failed, return empty tuples and let the calling command handle the issue by
+calling `failed_lxc`.
+"""
+function _lx_split_args_kwargs(s::String)::Tuple{Tuple, NamedTuple}
+    try
+        p = Meta.parse("_splitter_helper($s)")
+        e = eval(p)
+        if length(e) == 1
+            typeof(e) == Tuple && return (e, (;))
+            return ((), e)
+        else
+            return (e[1], NamedTuple(e[2]))
+        end
+    catch
+        return ((), (;))
+    end
+end
+
+_splitter_helper(a...; kw...) = (a, kw)
+

--- a/src/misc_utils.jl
+++ b/src/misc_utils.jl
@@ -11,9 +11,9 @@ Acts as joinpath.
 (/)(s...) = joinpath(s...)
 
 """
-    repr(s::AbstractString)
+    repr(o)
 
-Calls `repr` but strips away the `\"`.
+Calls `repr` but strips away the `\"` for string-like objects.
 """
 stripped_repr(s::AbstractString) = strip(repr(s), '\"')
 stripped_repr(o) = repr(o)

--- a/test/convert/lxfuns/utils.jl
+++ b/test/convert/lxfuns/utils.jl
@@ -1,0 +1,28 @@
+include(joinpath(@__DIR__, "..", "..", "utils.jl"))
+
+@testset "split arg" begin
+    s = """ :a, 5 """
+    a, kw = X._lx_split_args_kwargs(s)
+    @test a == (:a, 5)
+    @test kw == (;)
+
+    s = """ b=5, c=7 """
+    a, kw = X._lx_split_args_kwargs(s)
+    @test a == ()
+    @test kw == (; b=5, c=7)
+
+    s = """ :a, 5; foo="hello", bar=true """
+    a, kw = X._lx_split_args_kwargs(s)
+    @test a == (:a, 5)
+    @test kw == (; foo="hello", bar=true)
+
+    # seems happy to figure out args in the wrong order, not ideal but ok
+    s = """ foo="bar", 5 """
+    a, kw = X._lx_split_args_kwargs(s)
+    @test a == (5,)
+    @test kw == (;foo="bar")
+
+    s = """ foo, bar """
+    a, kw = X._lx_split_args_kwargs(s)
+    @test isempty(a) && isempty(kw)
+end

--- a/test/indir/literate.jl
+++ b/test/indir/literate.jl
@@ -43,3 +43,35 @@ include(joinpath(@__DIR__, "..", "utils.jl"))
     @test output_contains(FOLDER, "foo", "Pkg")
     @test output_contains(FOLDER, "foo", "literate/Project.toml")
 end
+
+@test_in_dir "_compl" "complement to i144" begin
+    write(FOLDER / "config.md", "")
+    write(FOLDER / "Project.toml", """
+        [deps]
+        Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
+        """)
+    write(FOLDER / "utils.jl", """
+        using Literate
+        """)
+    mkpath(FOLDER / "bar" / "baz")
+    write(FOLDER / "bar" / "baz" / "Project.toml", """
+        [deps]
+        StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
+        """)
+    write(FOLDER / "index.md", """
+        ```!
+        using Pkg
+        Pkg.project().path
+        ```
+        """)
+    write(FOLDER / "foo.md", raw"""
+        \activate{bar/baz}
+        ```!
+        using Pkg
+        Pkg.project().path
+        ```
+        """)
+    serve(FOLDER, single=true)
+    @test output_contains(FOLDER, "", "compl/Project.toml\"</code>")
+    @test output_contains(FOLDER, "foo", "bar/baz/Project.toml\"</code>")
+end

--- a/test/indir/literate.jl
+++ b/test/indir/literate.jl
@@ -1,0 +1,45 @@
+include(joinpath(@__DIR__, "..", "utils.jl"))
+
+@test_in_dir "_literate" "i144" begin
+    write(FOLDER / "config.md", "")
+    write(FOLDER / "Project.toml", """
+        [deps]
+        Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
+        """)
+    write(FOLDER / "utils.jl", """
+        using Literate
+        """
+    )
+    mkpath(FOLDER / "post")
+    write(FOLDER / "post" / "Project.toml", """
+        [deps]
+        StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
+        """)
+    write(FOLDER / "post" / "abc.jl", """
+        # abc 
+
+        using StableRNGs
+        rand(StableRNG(0)) ≈ 0.19506488073747286
+
+        # def
+
+        using Pkg
+        Pkg.project().path
+        """
+    )
+    write(FOLDER / "index.md", raw"""
+        \literate{post/abc.jl; project="."}
+        """)
+    write(FOLDER / "foo.md", """
+        ```!
+        using Pkg
+        Pkg.project().path
+        ```
+        """)
+
+    serve(FOLDER, single=true)
+    @test output_contains(FOLDER, "", ">true</code>")
+    @test output_contains(FOLDER, "", "post/Project.toml")
+    @test output_contains(FOLDER, "foo", "Pkg")
+    @test output_contains(FOLDER, "foo", "literate/Project.toml")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,14 +50,15 @@ include("utils.jl")
         include(p/"henv.jl")
     end
 
+    @testset "LxFuns" begin
+        p = "convert/lxfuns"
+        include(p/"utils.jl")
+    end
+
     @testset "EnvFuns" begin
         p = "convert/envfuns"
         include(p/"math.jl")
         include(p/"utils.jl")
-    end
-
-    @testset "LxFuns" begin
-        p = "convert/lxfuns"
     end
 
     # bug fixes etc
@@ -65,7 +66,6 @@ include("utils.jl")
         p = "convert/extras"
         include(p/"refs.jl")
     end
-
 
     @testset "build" begin
         p = "build"
@@ -115,6 +115,7 @@ end # basic
 
     @testset "general" begin
         include("indir" / "general.jl")
+        include("indir" / "literate.jl")
     end
 
 end # integration / in folder


### PR DESCRIPTION
### Pre-existing stuff

At any point in a file, a user can do `\activate{...}` which will try to activate+instantiate and code run after that will be in that project (unless changed). E.g.:

`foo.md`:
````
\activate{bar/baz}
```!
using Pkg
Pkg.project().path  # will show [folderpath]/bar/baz/Project.toml
```
````

This folder is deactivated after resolving the page (going back to whatever "parent" project was used before)

### New stuff

Literate can explicitly add a `project=...`, accepted syntax:

```
\literate{path/to/script.jl; project=.} # activate folder 'path/to'
\literate{path/to/script.jl; project="."} # same, quotes are not mandatory
\literate{path/to/script.jl; project="./foo"} # activate folder 'path/to/foo' (relative)
\literate{path/to/script.jl; project="foo/bar"} # activate folder 'foo/bar' (absolute with respect to folder path)
```

Example:

Folder `notebooks` with

* `Project.toml`
* `script.jl`

Main folder with file `index.md`

**Project.toml**:
```
[deps]
StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
```

**script.jl**
```
# abc

using StableRNGs
rand(StableRNG(0))

# def
```

**index.md**
```
Calling a literate script:

\literate{notebooks/script.jl; project=.}
```