### PR TITLE
cleanup of nb code cell eval

### DIFF
--- a/src/Xranklin.jl
+++ b/src/Xranklin.jl
@@ -44,11 +44,14 @@ export attach, cur_gc
 export toy_example
 export notebook
 
+# NOTE: these exports should not be confused with the functions loaded in Utils
+# NOTE: module that can be leveraged in var assignment and code cells. For that
+# NOTE: see the list UTILS_UTILS (in context/code/modules.jl)
 
 # ------------------------------------------------------------------------
 
 const FRANKLIN_ENV = Dict{Symbol, Any}(
-    :module_name       => "Xranklin",     # TODO: remove here, in newmodule, in delay
+    :module_name       => "Xranklin",     # TODO: remove when merging into Franklin
     :module_path       => Base.find_package("Xranklin"),
     :strict_parsing    => false,          # if true, fail on any parsing issue
     :offset_lxdefs     => -typemax(Int),  # helps keep track of order in lxcoms/envs
@@ -119,6 +122,7 @@ include("$p/default_context.jl")
 p = "context/code"
 include("$p/modules.jl")
 include("$p/notebook.jl")
+include("$p/eval.jl")
 include("$p/notebook_vars.jl")
 include("$p/notebook_code.jl")
 

--- a/src/build/serve.jl
+++ b/src/build/serve.jl
@@ -24,9 +24,13 @@ Runs Franklin in the directory `d` (current directory if unspecified).
     use_threads (Bool)  : [EXPERIMENTAL] if set to true, use multi-threading
                            in the full pass. You can only use this if there
                            is a single, site-wide environment (single Project
-                           and Manifest files). Also not recommended if one
-                           or several of your pages make use of multithreading
-                           themselves.
+                           and Manifest files). Also, if your pages make use of
+                           code (both page variables or actual code), then their
+                           processing will lock, effectively defeating the
+                           multi-threading. This is because code-execution needs
+                           to be captured, this is done with IOCapture which,
+                           for now, requires to be locked.
+                           https://github.com/JuliaDocs/IOCapture.jl/issues/14
 
     base_url_prefix (String)  : override the base url prefix and force it to a
                                  given value.

--- a/src/context/code/eval.jl
+++ b/src/context/code/eval.jl
@@ -1,0 +1,112 @@
+# VarsNotebook and CodeNotebook do different things with their code cells,
+# mostly in terms of how they recuperate and handle results.
+#
+# The VarsNotebook cares about *assignments* and so tries to recover that,
+# The CodeNotebook cares about *results* and so tries to capture that.
+#
+# The core of each is essentially the same though:
+#
+#   1. get a code cell
+#   2. hold the lock (to guarantee execution is done fully in one notebook)
+#   3. try to run the code
+#   4. recuperate results, stacktrace etc
+#   5. release the lock
+#   6. handle the results
+#
+# On top of that there may be some amount of information about the code being
+# evaluated etc.
+#
+disable_warn()  = Logging.disable_logging(Logging.Warn)
+get_loglevel()  = Base.CoreLogging._min_enabled_level[]
+set_loglevel(l) = (Base.CoreLogging._min_enabled_level[] = l;)
+
+
+struct EvalResult{T}
+    success::Bool
+    value::T
+    out::String    # prints to stdout
+    err::String    # prints to stderr
+end
+eval_result(; kw...) = EvalResult(
+    kw[:success],
+    kw[:value],
+    kw[:out],
+    kw[:err]
+)
+
+
+"""
+    eval_nb_cell(mdl, code; cell_name)
+
+Evaluate code `code` in module `mdl` where the code cell possibly has a name
+`cell_name` attached to it (the latter is only true for code cells, var
+assignment cells don't have a name).
+"""
+function eval_nb_cell(
+            mdl::Module,
+            code::String;
+            cell_name::String=""
+        )::EvalResult
+
+    lock(env(:lock))
+    cn       = ifelse(isempty(cell_name), "vars-assignment", cell_name)
+    start    = time(); @debug """
+            ⏳ evaluating code... $(hl(cn, :light_green))
+        """
+    loglevel = get_loglevel()
+
+    success = false
+    value   = nothing
+    out     = ""
+    err     = ""
+    
+    try
+        out, value = _attempt_eval(mdl, code)
+        success    = true
+        δt = time() - start; @debug """
+            ... [$(hl("cell", :blue)): $(hl(cn, :light_green))] ✔ $(hl(time_fmt(δt)))
+            """
+    catch
+        err = _process_eval_error(; cell_name)
+    finally
+        set_loglevel(loglevel)
+        unlock(env(:lock))
+    end
+
+    return eval_result(; success, value, out, err)
+end
+
+
+function _attempt_eval(mdl::Module, code::String)
+    captured = IOCapture.capture() do
+        include_string(softscope, mdl, code)
+    end
+    return captured.output, captured.value
+end
+
+
+function _process_eval_error(; cell_name::String="")
+    # also write to REPL so the user is doubly aware
+    # if we're in 'strict_parsing' mode then this will throw
+    # and interrupt the server
+    if VERSION >= v"1.7.0-"
+        exc, bt = last(Base.current_exceptions())
+    else
+        exc, bt = last(Base.catch_stack())
+    end
+    # retrieve the stacktrace string so it can be shown in repl
+    stacktrace = sprint(showerror, exc, bt) |> trim_stacktrace
+    
+    isvar = isempty(cell_name)
+    head  = ifelse(isvar, "Variables assignment code", "Code")
+    cname = ifelse(isvar, "", "('$cell_name')") 
+    msg   = """
+        <$head evaluation>
+        An error was caught when attempting to run code $cname
+        Details:
+        $stacktrace
+        """
+    env(:strict_parsing) && throw(msg)
+    @warn msg
+    return stacktrace
+end

--- a/test/context/code/code_show.jl
+++ b/test/context/code/code_show.jl
@@ -65,7 +65,7 @@ include(joinpath(@__DIR__, "..", "..", "utils.jl"))
         @test occursin("""sqrt will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).""", h)
         @test occursin("""Stacktrace:""", h)
         @test occursin("""throw_complex_domainerror""", h)
-    end "An error was caught when attempting to run a code cell ('ex')"
+    end "An error was caught when attempting to run code ('ex')"
 end
 
 @testset "figure" begin

--- a/test/context/code/eval.jl
+++ b/test/context/code/eval.jl
@@ -1,0 +1,38 @@
+include(joinpath(@__DIR__, "..", "..", "utils.jl"))
+
+@testset "eval" begin
+    mdl = Module()
+    x   = 5
+    code = """
+        x = $x
+        print(x)
+        x^2
+        """
+    er = X.eval_nb_cell(mdl, code; cell_name="abc")
+    @test er.success
+    @test er.value == x^2
+    @test er.out == "$x"
+    @test er.err == ""
+
+    # assignment (no cell name)
+    code = """
+        x = $x
+        """
+    er = X.eval_nb_cell(mdl, code)
+    @test er.success
+    @test er.value == 5
+    @test er.out == ""
+    @test er.err == ""
+
+    # error
+    code = """
+        x = sqrt(-1)
+        """
+    nowarn()
+    er = X.eval_nb_cell(mdl, code; cell_name="err")
+    logall()
+    @test !er.success
+    @test isnothing(er.value)
+    @test isempty(er.out)
+    @test contains(er.err, "DomainError with -1.0:")    
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -122,7 +122,7 @@ end # basic
         include(p/ "literate.jl")
         include(p/ "pagination.jl")
         include(p/ "rss.jl")
-    end
+    end 
 
 end # integration / in folder
 


### PR DESCRIPTION
into actual eval with identical logic.

One core element though is that now execution is always in a `IOCapture` block and so needs to be locked. So if there's any sort of code on a page, it'll lock which means that multithreading may generally not be very useful...

closes #200