### PR TITLE
Modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ test/abc_utils/__*
 toy_example/
 
 assets/
+
+sandbox.jl

--- a/src/Xranklin.jl
+++ b/src/Xranklin.jl
@@ -43,7 +43,7 @@ normalize_uri(s) = URIs.escapeuri(s, issafe)
 # ------------------------------------------------------------------------
 # Main functions
 export serve, build, html, html2, latex
-export attach, cur_gc
+export attach, cur_gc, cur_lc
 
 export toy_example
 export notebook
@@ -79,8 +79,6 @@ const FRANKLIN_ENV = Dict{Symbol, Any}(
 )
 env(s::Symbol)        = FRANKLIN_ENV[s]
 setenv!(s::Symbol, v) = (FRANKLIN_ENV[s] = v; nothing)
-
-const DUMMY_MODULE = Module() # for contexts which don't need notebooks
 
 const TIMER  = Dict{Float64,Pair{String, Float64}}()
 const TIMERN = Ref(0)

--- a/src/build/full_pass.jl
+++ b/src/build/full_pass.jl
@@ -470,7 +470,7 @@ function _html_loop(
     fpath = joinpath(fp...)
     opath = get_opath(gc, fpath)
     rpath = get_rpath(gc, fpath)
-    lc = gc.children_contexts[rpath]
+    lc    = gc.children_contexts[rpath]
 
     process_html_file(lc, fpath, opath, final)
     return

--- a/src/build/full_pass.jl
+++ b/src/build/full_pass.jl
@@ -384,14 +384,6 @@ function full_pass_markdown(
     iszero(n_watched) && return
     allocate_children_contexts(gc, watched)
 
-    use_threads = env(:use_threads)
-    entries     = nothing
-    n_entries   = 0
-    if use_threads
-        entries   = dic2vec(watched)
-        n_entries = length(entries)
-    end
-
     # keep track of files to skip (either because marked as such
     # or because their hash hasn't changed) so that they can also
     # be skipped in pass 2.
@@ -409,29 +401,16 @@ function full_pass_markdown(
     end
 
     # ----------------------------------------------------------------------
-    threaded = ifelse(
-        use_threads,
-        "using $(Threads.nthreads()) threads",
-        "threading disabled"
-    )
-    @info "> Full Pass [MD/1] ($threaded)"
+    @info "> Full Pass [MD/1]"
     rp(fp) = get_rpath(gc, joinpath(fp...))
     msg(fp, n="1️⃣") = " $n ⟨$(hl(str_fmt(rp(fp))))⟩"
-    if use_threads
-        info_thread(n_entries)
-        Threads.@threads for (fp, _) in entries
-            @info msg(fp)
-            skip = _md_loop_1(gc, fp, skip_dict, allow_init_skip)
-            skip && @info " ... ($(hl("skipped '$(rp(fp))'", :yellow)))"
-        end
-    else
-        for (fp, _) in watched
-            @info msg(fp)
-            skip = _md_loop_1(gc, fp, skip_dict, allow_init_skip)
-            skip && @info " ... ($(hl("skipped '$(rp(fp))'", :yellow)))"
-        end
+    for (fp, _) in watched
+        @info msg(fp)
+        skip = _md_loop_1(gc, fp, skip_dict, allow_init_skip)
+        skip && @info " ... ($(hl("skipped '$(rp(fp))'", :yellow)))"
     end
 
+    # ----------------------------------------------------------------------
     # Some pages may have been skipped from cache but should in fact be
     # done anyway because they depend upon a page that changed
     all_to_trigger = Set{String}()
@@ -443,21 +422,11 @@ function full_pass_markdown(
         for (fp, _) in watched
     )
     if any(values(check_trigger))
-        @info "> Full Pass [MD/1/reprocess] ($threaded)"
-        if use_threads
-            info_thread(n_entries)
-            Threads.@threads for (fp, _) in entries
-                if check_trigger[fp]
-                    @info " ... $(hl("♻ '$(get_rpath(gc, joinpath(fp...)))'", :green))"
-                    _md_loop_1(gc, fp; reproc=true)
-                end
-            end
-        else
-            for (fp, _) in watched
-                if check_trigger[fp]
-                    @info " ... $(hl("♻ '$(get_rpath(gc, joinpath(fp...)))'", :green))"
-                    _md_loop_1(gc, fp; reproc=true)
-                end
+        @info "> Full Pass [MD/1/reprocess]"
+        for (fp, _) in watched
+            if check_trigger[fp]
+                @info " ... $(hl("♻ '$(get_rpath(gc, joinpath(fp...)))'", :green))"
+                _md_loop_1(gc, fp; reproc=true)
             end
         end
     end
@@ -471,26 +440,15 @@ function full_pass_markdown(
             skip_dict[fp] = false
         end
     end
-
     # ----------------------------------------------------------------------
+
     @info "> Full Pass [MD/I] (sequential)"
     _md_loop_i(gc)
 
-    # ----------------------------------------------------------------------
-    @info "> Full Pass [MD/2] ($threaded)"
-    # now all page variables are uncovered and hfuns can be resolved
-    # without ambiguities. Assemble layout and iHTML, call html2 and write
-    if use_threads
-        info_thread(n_entries)
-        Threads.@threads for (fp, _) in entries
-            @info msg(fp, "2️⃣")
-            _md_loop_2(gc, fp, skip_dict, final)
-        end
-    else
-        for (fp, _) in watched
-            @info msg(fp, "2️⃣")
-            _md_loop_2(gc, fp, skip_dict, final)
-        end
+    @info "> Full Pass [MD/2]"
+    for (fp, _) in watched
+        @info msg(fp, "2️⃣")
+        _md_loop_2(gc, fp, skip_dict, final)
     end
 
     return
@@ -531,22 +489,9 @@ function full_pass_html(
     iszero(n_watched) && return
     allocate_children_contexts(gc, watched)
 
-    threaded = ifelse(
-        use_threads,
-        "using $(Threads.nthreads()) threads",
-        "threading disabled"
-    )
-    @info "> Full Pass [HTML] ($threaded)"
-    if use_threads
-        entries = dic2vec(watched)
-        info_thread(length(entries))
-        Threads.@threads for (fp, _) in entries
-            _html_loop(gc, fp, skip_files, final)
-        end
-    else
-        for (fp, _) in watched
-            _html_loop(gc, fp, skip_files, final)
-        end
+    @info "> Full Pass [HTML]"
+    for (fp, _) in watched
+        _html_loop(gc, fp, skip_files, final)
     end
     return
 end
@@ -561,16 +506,16 @@ function full_pass_other(
     n_watched = length(watched)
     iszero(n_watched) && return
 
-    @info "> Full Pass [O] (always threaded)"
+    @info "> Full Pass [O]"
     entries = dic2vec(watched)
-    info_thread(length(entries))
+    @info "🧵 loop (n=$(Threads.nthreads())) over $(length(entries)) items"
     Threads.@threads for (fp, _) in dic2vec(watched)
         fpath = joinpath(fp...)
         if fp in skip_files ||
            startswith(fpath, path(gc, :layout)) ||
            startswith(fpath, path(gc, :rss))
 
-            continue
+           continue
         end
 
         # copy the file over if it's not there in the current form

--- a/src/build/serve.jl
+++ b/src/build/serve.jl
@@ -134,8 +134,7 @@ function serve(
         config_unchanged || break
     end
 
-    deserialized_gc = false
-
+    deserialized_gc_success = false
     if !clear && isfile(gc_cache_path())
         start = time()
         # try to load previously-serialised contexts if any, the process config
@@ -146,7 +145,7 @@ function serve(
             δt = time() - start; @info """
                 🏁 ... done $(hl(time_fmt(δt), :red))
                 """
-            deserialized_gc = true
+            deserialized_gc_success = true
         catch
             @info """
                 ❌ failed to deserialize cache, maybe the previous session crashed.
@@ -159,7 +158,9 @@ function serve(
     end
 
     if clear || !utils_unchanged
-        if deserialized_gc
+        # if there was a successfully deserialised gc, we discard it
+        # if there wasn't, then the gc is currently a fresh one
+        if deserialized_gc_success
             # changed_layout_hashes -> restart from scratch
             folder = path(gc, :folder)
             gc     = DefaultGlobalContext()

--- a/src/build/serve.jl
+++ b/src/build/serve.jl
@@ -103,6 +103,7 @@ function serve(
     # both the global and the local contexts) will live.
     gc     = DefaultGlobalContext()
     folder = ifelse(isempty(folder), pwd(), dir)
+
     set_paths!(gc, folder)
 
     # activate the folder environment

--- a/src/context/code/notebook_vars.jl
+++ b/src/context/code/notebook_vars.jl
@@ -16,6 +16,10 @@ function eval_vars_cell!(
         )::Nothing
     isempty(cell_code) && return
 
+    if ctx isa LocalContext && ctx !== cur_lc()
+        set_current_local_context(ctx)
+    end
+
     nb   = ctx.nb_vars
     cntr = counter(nb)
     lnb  = length(nb)

--- a/src/context/context.jl
+++ b/src/context/context.jl
@@ -170,7 +170,8 @@ end
 # Note that when a local context is created it is automatically
 # attached to its global context via the children_contexts
 function LocalContext(
-            glob, vars, defs, headings, rpath, alias=Alias()
+            glob, vars, defs, headings, rpath;
+            alias=Alias(), keep_current_lc::Bool=false
         )
 
     if isempty(rpath)
@@ -216,7 +217,7 @@ function LocalContext(
     # *must* be done after attachment as depends on children context
     # for the setup of the code module, see comment earlier at instantiation
     # of nb_code.
-    set_current_local_context(lc)
+    keep_current_lc || set_current_local_context(lc)
     setup_var_module(lc)
     return lc
 end
@@ -225,11 +226,14 @@ function LocalContext(
             g=GlobalContext(),
             v=Vars(),
             d=LxDefs();
+            #
             rpath="",
-            alias=Alias()
+            alias=Alias(),
+            keep_current_lc::Bool=false,
         )
     return LocalContext(
-        g, v, d, PageHeadings(), rpath, alias
+        g, v, d, PageHeadings(), rpath;
+        alias, keep_current_lc
     )
 end
 

--- a/src/context/context_utils.jl
+++ b/src/context/context_utils.jl
@@ -18,10 +18,10 @@ set_recursive!(c::LocalContext)  = (c.is_recursive[] = true; c)
 is_math(c::GlobalContext) = false
 is_math(c::LocalContext)  = c.is_math[]
 
-
-function hasvar(gc::GlobalContext, n::Symbol)
-    return n in keys(gc.vars) || n in keys(gc.vars_aliases)
+function hasvar(c::Context, n::Symbol)
+    return n in keys(c.vars) || n in keys(c.vars_aliases)
 end
+
 
 """
     req_var!(src, req, req_var, default)
@@ -201,8 +201,14 @@ function set_current_global_context(gc::GlobalContext)::GlobalContext
     gc
 end
 
+function set_current_local_context(lc::LocalContext)::LocalContext
+    setenv!(:cur_local_ctx, lc)
+    lc
+end
+
 # helper functions to retrieve current local/global context
 cur_gc() = env(:cur_global_ctx)::GlobalContext
+cur_lc() = env(:cur_local_ctx)::Union{Nothing,LocalContext}
 
 
 # ---------------- #

--- a/src/context/default_context.jl
+++ b/src/context/default_context.jl
@@ -230,7 +230,7 @@ function TagLocalContext(
         gc::GlobalContext;
         rpath::String=""
     )
-    LocalContext(gc; rpath, keep_current_lc=true)
+    LocalContext(gc; rpath)
 end
 
 # Detached context for simple eval str

--- a/src/context/default_context.jl
+++ b/src/context/default_context.jl
@@ -208,7 +208,7 @@ function DefaultGlobalContext()
         alias=copy(DefaultGlobalVarsAlias)
     )
     setvar!(gc, :project, Pkg.project().path)
-    set_current_global_context(gc)
+    return gc
 end
 
 function DefaultLocalContext(gc::GlobalContext; rpath::String="")
@@ -220,15 +220,17 @@ function DefaultLocalContext(gc::GlobalContext; rpath::String="")
         rpath
     )
 end
-DefaultLocalContext(; kw...) = DefaultLocalContext(env(:cur_global_ctx); kw...)
-DefaultLocalContext(::Nothing; kw...) = DefaultLocalContext(DefaultGlobalContext(); kw...)
+DefaultLocalContext(; kw...) =
+    DefaultLocalContext(env(:cur_global_ctx); kw...)
+DefaultLocalContext(::Nothing; kw...) =
+    DefaultLocalContext(DefaultGlobalContext(); kw...)
 
-# for html pages
-function SimpleLocalContext(
+# for tag pages
+function TagLocalContext(
         gc::GlobalContext;
         rpath::String=""
     )
-    LocalContext(gc; rpath)
+    LocalContext(gc; rpath, keep_current_lc=true)
 end
 
 # Detached context for simple eval str

--- a/src/context/notebook.jl
+++ b/src/context/notebook.jl
@@ -47,8 +47,11 @@ struct VarsNotebook <: Notebook
     code_pairs::VarsCodePairs
     is_stale::Ref{Bool}
 end
-VarsNotebook(mdl::Module=DUMMY_MODULE) =
+VarsNotebook(mdl::Module) =
     VarsNotebook(mdl, Ref(1), VarsCodePairs(), Ref(false))
+
+
+const DUMMY_CODE_MODULE = Module(:dummy_code_module, false, false)
 
 """
     CodeNotebook
@@ -66,8 +69,10 @@ Same as VarsNotebook with additionally
     indep_code: keeps track of mapping {code_string => code_repr} for code
                  blocks explicitly marked as 'indep' so that their result
                  is "frozen" and the cell can be skipped.
+    repl_code_hash: list of repl blocks and their hash (so that if they change
+                    they get reevaluated).
 """
-struct CodeNotebook <: Notebook
+mutable struct CodeNotebook <: Notebook
     # see VarsNotebook
     mdl::Module
     cntr_ref::Ref{Int}
@@ -78,7 +83,7 @@ struct CodeNotebook <: Notebook
     indep_code::Dict{String, CodeRepr}
     repl_code_hash::Dict{String, UInt64}
 end
-CodeNotebook(mdl::Module=DUMMY_MODULE) =
+CodeNotebook(mdl::Module=DUMMY_CODE_MODULE) =
     CodeNotebook(mdl, Ref(1), CodeCodePairs(),
                  String[], Ref(false),
                  Dict{String, CodeRepr}(),
@@ -87,3 +92,5 @@ CodeNotebook(mdl::Module=DUMMY_MODULE) =
 is_stale(nb::Notebook)        = nb.is_stale[]
 stale_notebook!(nb::Notebook) = (nb.is_stale[] = true;)
 fresh_notebook!(nb::Notebook) = (nb.is_stale[] = false;)
+
+is_dummy(nb::CodeNotebook) = (nb.mdl === DUMMY_CODE_MODULE)

--- a/src/context/tags.jl
+++ b/src/context/tags.jl
@@ -122,10 +122,9 @@ function write_tag_page(
     end
 
     # convert tag layout and write to file (we don't care about retrieving it from GC)
-    lc = SimpleLocalContext(gc; rpath="__tag__")
+    lc = TagLocalContext(gc; rpath=trp)
     setvar!(lc, :tag_id, id)
     setvar!(lc, :tag_name, gc.tags[id].name)
-    setvar!(lc, :_relative_path, trp)
     open(tp, "w") do f
         write(f, html2(ct, lc))
     end

--- a/src/convert/markdown/lxfuns/literate.jl
+++ b/src/convert/markdown/lxfuns/literate.jl
@@ -135,7 +135,7 @@ function _process_literate_file(
          )::String
     # check if Literate.jl is loaded, otherwise interrupt
     if !env(:literate)
-        if !isdefined(utils_module(lc), :Literate)
+        if !isdefined(get_utils_module(lc), :Literate)
             @warn """
                 \\literate{...}
                 It looks like you have not imported Literate in your Utils.
@@ -146,7 +146,7 @@ function _process_literate_file(
             setenv!(:literate, true)
         end
     end
-    L = utils_module(lc).Literate
+    L = get_utils_module(lc).Literate
 
     # check the version, we want a version after 2.9 as that's the one that
     # introduced the 4-backticks fence (as opposed to 3 earlier).

--- a/src/convert/outputof.jl
+++ b/src/convert/outputof.jl
@@ -18,7 +18,7 @@ function outputof(
                 f(lc; tohtml) :
                 f(lc, args; tohtml)
     else
-        f = getproperty(utils_module(lc), fsymb)
+        f = getproperty(get_utils_module(lc), fsymb)
         res = hasmethod(f, Tuple{Vector{String}}, (:tohtml,)) ?
                    ( # there is a method with a ;tohtml
                      isempty(args) ?

--- a/src/convert/postprocess/dbb.jl
+++ b/src/convert/postprocess/dbb.jl
@@ -157,7 +157,7 @@ function _dbb_fill(
 
     # try fill from Utils
     elseif !fail && (fname in utils_var_names(lc.glob))
-        mdl = utils_module(lc)
+        mdl = get_utils_module(lc)
         res = string(getproperty(mdl, fname))
 
     else

--- a/src/convert/postprocess/hfuns/evalstr.jl
+++ b/src/convert/postprocess/hfuns/evalstr.jl
@@ -41,7 +41,7 @@ function eval_str(
     code = replace(code, "⁰" => "\"")
 
     res = eval_nb_cell(
-        utils_module(lc),
+        get_utils_module(lc),
         code,
         cell_name = "__estr__"
     )

--- a/src/misc_utils.jl
+++ b/src/misc_utils.jl
@@ -63,12 +63,6 @@ function str_fmt(s::AbstractString, l=65)
     return "[...]$ss"
 end
 
-
-function info_thread(n::Int)
-    @info "🧵 loop (n=$(Threads.nthreads())) over $n items"
-end
-
-
 """
     change_ext(fname, new_extension)
 

--- a/src/process/md/pass_1.jl
+++ b/src/process/md/pass_1.jl
@@ -25,6 +25,10 @@ function process_md_file_pass_1(
 
     crumbs(@fname)
 
+    # Note: this is called from process_md_file which is
+    # called from process_file which sets the cur_lc so
+    # necessarily we have lc === cur_lc() here.
+
     prev_hash     = lc.page_hash[]
     from_cache    = !iszero(prev_hash)
     ignore_cache  = from_cache & getvar(lc, :ignore_cache, false)

--- a/src/process/md/pass_2.jl
+++ b/src/process/md/pass_2.jl
@@ -11,6 +11,11 @@ function process_md_file_pass_2(
 
     crumbs(@fname)
 
+    # Note that here we must ensure that cur_lc is set
+    # properly as this is called in a second phase so it's
+    # not guaranteed that lc === cur_lc
+    set_current_local_context(lc)
+
     ihtml = getvar(lc, :_generated_ihtml, "")
     odir  = dirname(opath)
     cleanup_paginated(odir)

--- a/src/process/md/pass_i.jl
+++ b/src/process/md/pass_i.jl
@@ -9,6 +9,13 @@ function process_md_file_pass_i(
 
     crumbs(@fname)
 
+    # Note that here lc is not necessarily equal to cur_lc
+    # unlike in pass_1 where this is guaranteed by the fact
+    # that the pass 1 is called directly after process_file
+    # which makes sure of it.
+    # For the intermediate file though we don't care because
+    # there's no Utils-style processing.
+
     gc    = lc.glob
     rpath = lc.rpath
 
@@ -26,7 +33,8 @@ function process_md_file_pass_i(
     setvar!(lc, :_rm_tags, default)
 
     # Tags to add
-    for (id, name) in getvar(lc, :_add_tags)
+    default = Pair{String}[]
+    for (id, name) in getvar(lc, :_add_tags, default)
         add_tag(gc, id, name, rpath)
     end
     setvar!(lc, :_add_tags, default)

--- a/src/process/process.jl
+++ b/src/process/process.jl
@@ -62,6 +62,8 @@ function process_file(
                     gc.children_contexts[rpath]     :
                     DefaultLocalContext(gc; rpath)
 
+        set_current_local_context(lc)
+
         # to check nesting of re-processing + the *context* has changed and so
         # as a result all cells (apart from indep ones potentially) must be
         # re-evaluated.

--- a/src/process/utils.jl
+++ b/src/process/utils.jl
@@ -1,12 +1,20 @@
-function set_meta_parameters(lc::LocalContext, fpath::String, opath::String)
+function set_meta_parameters(
+            lc::LocalContext,
+            fpath::String,
+            opath::String
+        )::Nothing
+
     rpath  = get_rpath(lc.glob, fpath)
     ropath = get_ropath(lc.glob, opath)
+    
     s = stat(fpath)
     setvar!(lc, :_output_path, opath)
     setvar!(lc, :_relative_path, rpath)
     setvar!(lc, :_relative_url, unixify(ropath))
     setvar!(lc, :_creation_time, s.ctime)
     setvar!(lc, :_modification_time, s.mtime)
+    
+    return
 end
 
 

--- a/test/_1_basics.jl
+++ b/test/_1_basics.jl
@@ -6,6 +6,7 @@ include("utils.jl")
     include(p/"context.jl")
     include(p/"default_context.jl")
     include(p/"serialize.jl")
+    include(p/"order.jl")
 end
 
 @testset "Context/Code" begin

--- a/test/_2_indir.jl
+++ b/test/_2_indir.jl
@@ -6,15 +6,20 @@ include("utils.jl")
 end
 
 @testset "general" begin
-    p = "indir"
+    p = "indir"/"general"
     include(p/"general.jl")
-    include(p/"literate.jl")
-    include(p/"pagination.jl")
     include(p/"hfuns.jl")
-    include(p/"rss.jl")
-    include(p/"sitemap-robots.jl")
     include(p/"eval_order.jl")
     include(p/"config.jl")
     include(p/"utils.jl")
     include(p/"errors.jl")
 end 
+
+@testset "aux" begin
+    p = "indir"/"aux"
+    include(p/"literate.jl")
+    include(p/"rss.jl")
+    include(p/"sitemap-robots.jl")
+    include(p/"pagination.jl")
+    include(p/"tags.jl")
+end

--- a/test/_x_perf.jl
+++ b/test/_x_perf.jl
@@ -1,0 +1,54 @@
+include("utils.jl")
+using Random
+using BenchmarkTools
+
+#
+# Gist here is that per page, the processing time should be
+# no more than 10ms (exec cell code time excluded).
+#
+# - instantiation of context (DefaultLocalContext)
+# - parsing and resolution
+# - assembling of page + writing page
+#
+# idea being that the processing of 100 pages would then take
+# 1 second (less would be better of course)
+# 
+
+# ====================================
+# Time to create a DefaultLocalContext
+# as of 29/7/2023 it's around 0.33ms. 
+begin
+    u = raw"""
+    import Literate
+    @reexport using Dates
+    using Literate
+    import Hyperscript as HS
+
+    node = HS.m
+
+    dfmt(d) = Dates.format(d, "U d, yyyy")
+    function hfun_dfmt(p::Vector{String})
+        d = getlvar(Symbol(p[1]))
+        return dfmt(d)
+    end
+    function hfun_page_tags()
+        tags = get_page_tags()
+        base = globvar(:tags_prefix)
+        return join(
+            (
+                node("span", class="tag",
+                    node("a", href="/$base/$id/", name)
+                )
+                for (id, name) in tags
+            ),
+            node("span", class="separator", "•")
+        )
+    end
+    function hfun_taglist()
+        return hfun_list_posts(getlvar(:tag_name))
+    end
+    """
+
+    gc = X.DefaultGlobalContext()
+    @btime X.DefaultLocalContext($gc; rpath=randstring(5));
+end

--- a/test/bugs/worldage.jl
+++ b/test/bugs/worldage.jl
@@ -29,3 +29,16 @@ end
         @test X.outputof(:hfun_foo, String[], lcu; internal=false) == "bar"
     end
 end
+
+# TODO: removing Base.@invokelatest will make this fail. See tjd/xr/xrt3
+@test_in_dir "_worldage" "worldage" begin
+    write(FOLDER/"index.md", """
+        ABC {{foo}}
+        """)
+    write(FOLDER/"utils.jl", """
+        hfun_foo() = :bar
+        """)
+    write(FOLDER/"skeleton.html", "")
+    build(FOLDER)
+    # @test_throws MethodError build(FOLDER)
+end

--- a/test/context/code/modules.jl
+++ b/test/context/code/modules.jl
@@ -39,14 +39,13 @@ end
     X.setvar!(gc, :abc, 1//2)
     utils = """
         foo() = getgvar(:abc)
+        rp() = get_rpath()
         """
     X.process_utils(gc, utils)
-    @test X.utils_module(gc).foo() == 1//2
+    @test X.get_utils_module(gc).foo() == 1//2
 
     lc = X.DefaultLocalContext(gc; rpath="loc")
     @test lc.nb_vars.mdl.Utils.foo() == 1//2
 
-    U = X.utils_module(lc)
-    @test U.foo() == 1//2
-    @test U.get_rpath() == X.get_rpath(lc) == "loc"
+    @test include_string(lc.nb_vars.mdl, "Utils.rp()") == "loc"
 end

--- a/test/context/code/notebook_code.jl
+++ b/test/context/code/notebook_code.jl
@@ -6,11 +6,15 @@ include(joinpath(@__DIR__, "..", "..", "utils.jl"))
     lc = X.DefaultLocalContext(gc; rpath="foo")
     nb = lc.nb_code
     @test isa(nb, X.CodeNotebook)
+    
+    @test X.is_dummy(nb)
     c = """
         a = 5
         a^2
         """
     X.eval_code_cell!(lc, X.subs(c), "abc")
+    @test !X.is_dummy(nb)
+
     @test X.counter(nb) == 2
     @test length(nb) == 1
     @test nb.code_pairs[1].repr.html // """

--- a/test/context/code/notebook_vars.jl
+++ b/test/context/code/notebook_vars.jl
@@ -4,9 +4,9 @@ include(joinpath(@__DIR__, "..", "..", "utils.jl"))
     lc = X.DefaultLocalContext(rpath="foo")
     @test isa(lc.nb_vars, X.VarsNotebook)
     @test nameof(lc.nb_vars.mdl) == X.modulename("foo_vars", true)
-    @test nameof(lc.nb_code.mdl) == X.modulename("foo_code", true)
-    @test length(lc.nb_vars) == 0
-    @test X.counter(lc.nb_vars) == 1
+
+    # by default, lc code is not active
+    @test X.is_dummy(lc.nb_code)
 
     v = """
         a = 5

--- a/test/context/order.jl
+++ b/test/context/order.jl
@@ -1,0 +1,46 @@
+include(joinpath(@__DIR__, "..", "utils.jl"))
+
+#
+# Making sure that cur_lc always refers to the correct path
+#
+
+@testset "order getvar/getvarfrom" begin
+    gc = X.DefaultGlobalContext()
+    l1 = X.DefaultLocalContext(gc; rpath="l1")
+    l2 = X.DefaultLocalContext(gc; rpath="l2")
+
+    s2 = """
+        ```!
+        # hideall
+        setlvar!(:a2, 10)
+        ```
+        """
+    h2 = html(s2, l2)
+    @test h2 == ""
+
+    s1 = """
+        ```!
+        # hideall
+        setlvar!(:a1, 5)
+        ```
+
+        ```!
+        getlvar(:a1)^2
+        ```
+
+        ```!
+        getvarfrom(:a2, "l2")
+        ```
+
+        ```!
+        getlvar(:a1)/2
+        ```
+        """
+    h1 = html(s1, l1)
+
+    for e in (
+        "25", "10", "2.5"
+    )
+        @test occursin(e, h1)
+    end
+end

--- a/test/indir/aux/literate.jl
+++ b/test/indir/aux/literate.jl
@@ -1,4 +1,4 @@
-include(joinpath(@__DIR__, "..", "utils.jl"))
+include(joinpath(@__DIR__, "..", "..", "utils.jl"))
 
 @test_in_dir "_literate" "i144" begin
     write(FOLDER / "config.md", "")

--- a/test/indir/aux/pagination.jl
+++ b/test/indir/aux/pagination.jl
@@ -1,4 +1,4 @@
-include(joinpath(@__DIR__, "..", "utils.jl"))
+include(joinpath(@__DIR__, "..", "..", "utils.jl"))
 
 @test_in_dir "_pagination" "i198" begin
     write(FOLDER / "config.md", "")

--- a/test/indir/aux/rss.jl
+++ b/test/indir/aux/rss.jl
@@ -1,4 +1,4 @@
-include(joinpath(@__DIR__, "..", "utils.jl"))
+include(joinpath(@__DIR__, "..", "..", "utils.jl"))
 
 RSS_HEAD = """
   <?xml version="1.0" encoding="UTF-8"?>

--- a/test/indir/aux/sitemap-robots.jl
+++ b/test/indir/aux/sitemap-robots.jl
@@ -1,4 +1,4 @@
-include(joinpath(@__DIR__, "..", "utils.jl"))
+include(joinpath(@__DIR__, "..", "..", "utils.jl"))
 
 @test_in_dir "_smr" "sitemap+robots" begin
     mkpath(FOLDER / "norobots")

--- a/test/indir/aux/tags.jl
+++ b/test/indir/aux/tags.jl
@@ -47,7 +47,7 @@ include(joinpath(@__DIR__, "..", "..", "utils.jl"))
 
         {{curpagetags}}
         """)
-    build(FOLDER, cleanup=false)
+    build(FOLDER)
 
     for f in [
         "__site"/"tags"/"t$i"/"index.html"
@@ -89,4 +89,23 @@ include(joinpath(@__DIR__, "..", "..", "utils.jl"))
 
     c = read(FOLDER/"__site"/"index.html", String)
     @test occursin("n-tags: 4", c)
+end
+
+
+@test_in_dir "_tags" "tag env" begin
+    write(FOLDER/"config.md", "")
+    write(FOLDER/"utils.jl", "")
+    write(FOLDER/"_layout"/"tag.html", """
+        {{fill tag_name}}
+        """)
+    write(FOLDER/"index.md", """
+        +++
+        tags = ["A TaG", "B TaG 2"]
+        +++
+        ABC
+        """)
+    build(FOLDER)
+
+    @test output_contains(FOLDER, "tags"/"a_tag", "A TaG")
+    @test output_contains(FOLDER, "tags"/"b_tag_2", "B TaG 2")
 end

--- a/test/indir/aux/tags.jl
+++ b/test/indir/aux/tags.jl
@@ -1,0 +1,92 @@
+include(joinpath(@__DIR__, "..", "..", "utils.jl"))
+
+@test_in_dir "_tags" "base" begin
+    write(FOLDER/"config.md", "")
+    write(FOLDER/"utils.jl", raw"""
+        function hfun_curpagetags()
+            pt = get_page_tags(cur_lc())
+            io = IOBuffer()
+            println(io, "<ul>")
+            for (id, name) in pt
+                println(io, "<li>$id -- $name</li>")
+            end
+            println(io, "</ul>")
+            return String(take!(io))
+        end
+
+        function hfun_ntags()
+            at = get_all_tags()
+            return repr(length(at))
+        end
+        """)
+    write(FOLDER/"index.md", """
+        n-tags: {{ntags}}
+        """)
+
+    write(FOLDER/"abc.md", """
+        +++
+        tags = ["t1", "t2", "t3"]
+        barz = 1//2
+        +++
+        # ABC title
+        foo
+
+        {{fill fooz def}}
+
+        {{barz}}
+
+        {{curpagetags}}
+        """)
+    write(FOLDER/"def.md", """
+        +++
+        tags = ["t2", "t3", "t4"]
+        fooz = 3//5
+        +++
+        # DEF title
+        bar
+
+        {{curpagetags}}
+        """)
+    build(FOLDER, cleanup=false)
+
+    for f in [
+        "__site"/"tags"/"t$i"/"index.html"
+        for i in [1,2,3,4]
+    ]
+        @test isfile(FOLDER/f)
+    end
+
+    # t2 has 2 refs
+    c = read(FOLDER/"__site"/"tags"/"t2"/"index.html", String)
+    for e in (
+        "<a href=\"/def/\">DEF title</a>",
+        "<a href=\"/abc/\">ABC title</a>"
+    )
+        @test occursin(e, c)
+    end
+
+    # execution of hfuns should be unaffected
+    c = read(FOLDER/"__site"/"abc"/"index.html", String)
+    for e in (
+        "3//5", "1//2", 
+    )
+        @test occursin(e, c)
+    end
+    for e in (
+        "<li>t$i -- t$i</li>"
+        for i in (1,2,3)
+    )   
+        @test occursin(e, c)
+    end
+
+    c = read(FOLDER/"__site"/"def"/"index.html", String)
+    for e in (
+        "<li>t$i -- t$i</li>"
+        for i in (2,3,4)
+    )   
+        @test occursin(e, c)
+    end
+
+    c = read(FOLDER/"__site"/"index.html", String)
+    @test occursin("n-tags: 4", c)
+end

--- a/test/indir/general/config.jl
+++ b/test/indir/general/config.jl
@@ -1,4 +1,4 @@
-include(joinpath(@__DIR__, "..", "utils.jl"))
+include(joinpath(@__DIR__, "..", "..", "utils.jl"))
 
 
 @test_in_dir "_order" "i228" begin

--- a/test/indir/general/errors.jl
+++ b/test/indir/general/errors.jl
@@ -1,4 +1,4 @@
-include(joinpath(@__DIR__, "..", "utils.jl"))
+include(joinpath(@__DIR__, "..", "..", "utils.jl"))
 
 
 @test_in_dir "_errors" "parsing/basic" begin

--- a/test/indir/general/eval_order.jl
+++ b/test/indir/general/eval_order.jl
@@ -1,4 +1,4 @@
-include(joinpath(@__DIR__, "..", "utils.jl"))
+include(joinpath(@__DIR__, "..", "..", "utils.jl"))
 
 @test_in_dir "_order" "i228" begin
     txt = raw"""

--- a/test/indir/general/general.jl
+++ b/test/indir/general/general.jl
@@ -1,4 +1,4 @@
-include(joinpath(@__DIR__, "..", "utils.jl"))
+include(joinpath(@__DIR__, "..", "..", "utils.jl"))
 
 @test_in_dir "_triggers" "i107" begin
     write(FOLDER / "counter", 0)

--- a/test/indir/general/hfuns.jl
+++ b/test/indir/general/hfuns.jl
@@ -1,4 +1,4 @@
-include(joinpath(@__DIR__, "..", "utils.jl"))
+include(joinpath(@__DIR__, "..", "..", "utils.jl"))
 
 @test_in_dir "_for-estr" "for and estring" begin
     write(FOLDER / "config.md", "")

--- a/test/indir/general/utils.jl
+++ b/test/indir/general/utils.jl
@@ -1,4 +1,4 @@
-include(joinpath(@__DIR__, "..", "utils.jl"))
+include(joinpath(@__DIR__, "..", "..", "utils.jl"))
 
 # also testing reexports
 @test_in_dir "_reexp" "rexp" begin


### PR DESCRIPTION
This closes #248, closes #247, closes #249 by exposing `cur_lc` globally. This also means that, for now, threading is shelved (it had already been hamstrung by the fact that code evaluation required locking; this should be revisited with the help of someone who really knows how to have proper threaded code). 

Basically now FranklinCore and Utils are only defined in the global var module to make local contexts much lighter (and faster) to run. There's a 100x speedup here.

Will now stress test this with the repo in #243 then merge.